### PR TITLE
[fix] 배포 시 gradle 권한 부여

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
+      - name: Grant execute permission to Gradle Wrapper
+        run: chmod +x ./gradlew
       - name: Build and push image to Amazon ECR
         run: ./gradlew clean jib -x test
       - name: Deploy to AWS ECS


### PR DESCRIPTION
## 관련 이슈

- [K5P-39] 

## 구현 기능

- 배포 시 gradle 권한 부여

## 세부 작업 내용

- [x] 배포 시 gradle 권한 부여

## 참고 사항

[K5P-39]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ