### PR TITLE
[env] cors 허용

### DIFF
--- a/src/main/java/site/billingwise/api/serverapi/global/config/WebConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package site.billingwise.api.serverapi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:5173",
+                        "https://billingwise.site"
+                )
+                .allowedMethods("*");
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- [K5P-38]

## 구현 기능

- cors 허용

## 세부 작업 내용

- [x] 개발 환경 http://localhost:5173에 cors 허용 
- [x] 배포 환경 https://billingwise.site에 cors 허용

## 참고 사항

[K5P-38]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ