### PR TITLE
[feat] 상품 정보 수정 API

### DIFF
--- a/src/docs/asciidoc/api/item.adoc
+++ b/src/docs/asciidoc/api/item.adoc
@@ -14,9 +14,18 @@
 operation::item/create[snippets='http-request,request-parts,request-part-data-fields,http-response']
 
 
+=== 상품 정보 수정
+
+상품 정보를 수정합니다.
+
+operation::item/edit-info[snippets='http-request,request-fields,http-response']
+
+
 === 상품 이미지 수정
 
 상품 이미지를 수정합니다.
 
-operation::item/edit-image[snippets='http-request,request-parts,request-part-data-fields,http-response']
+operation::item/edit-image[snippets='http-request,request-parts,http-response']
+
+
 

--- a/src/docs/asciidoc/api/item.adoc
+++ b/src/docs/asciidoc/api/item.adoc
@@ -18,14 +18,20 @@ operation::item/create[snippets='http-request,request-parts,request-part-data-fi
 
 상품 정보를 수정합니다.
 
-operation::item/edit-info[snippets='http-request,request-fields,http-response']
+operation::item/edit-info[snippets='http-request,path-parameters,request-fields,http-response']
 
 
 === 상품 이미지 수정
 
 상품 이미지를 수정합니다.
 
-operation::item/edit-image[snippets='http-request,request-parts,http-response']
+operation::item/edit-image[snippets='http-request,path-parameters,request-parts,http-response']
 
+
+=== 상품 삭제
+
+상품 정보를 삭제합니다.
+
+operation::item/delete[snippets='http-request,path-parameters,http-response']
 
 

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
@@ -46,4 +46,16 @@ public class Item extends BaseEntity {
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setPrice(Long price) {
+        this.price = price;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
@@ -16,6 +16,7 @@ import site.billingwise.api.serverapi.global.response.BaseResponse;
 import site.billingwise.api.serverapi.global.response.info.SuccessInfo;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -55,6 +56,15 @@ public class ItemController {
         itemService.editItemImage(itemId, multipartFile);
 
         return new BaseResponse(SuccessInfo.ITEM_IMAGE_EDITED);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/{itemId}")
+    public BaseResponse deleteItem(@PathVariable Long itemId) {
+
+        itemService.deleteItem(itemId);
+
+        return new BaseResponse(SuccessInfo.ITEM_DELETED);
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
+import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
 import site.billingwise.api.serverapi.domain.item.service.ItemService;
 import site.billingwise.api.serverapi.global.response.BaseResponse;
 import site.billingwise.api.serverapi.global.response.info.SuccessInfo;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,12 +30,21 @@ public class ItemController {
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping()
-    public BaseResponse createItem(@Valid @RequestPart(name = "data") CreateItemDto writePostRequestDto,
+    public BaseResponse createItem(@Valid @RequestPart(name = "data") CreateItemDto createItemDto,
             @RequestPart(name = "image", required = false) MultipartFile multipartFile) {
 
-        itemService.createItem(writePostRequestDto, multipartFile);
+        itemService.createItem(createItemDto, multipartFile);
 
         return new BaseResponse(SuccessInfo.ITEM_CREATED);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping("/{itemId}")
+    public BaseResponse editItem(@PathVariable Long itemId, @Valid @RequestBody EditItemDto editItemDto) {
+
+        itemService.editItem(itemId, editItemDto);
+
+        return new BaseResponse(SuccessInfo.ITEM_EDITED);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/CreateItemDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/CreateItemDto.java
@@ -19,13 +19,13 @@ public class CreateItemDto {
 
 	private String description;
 
-	public Item toEntity(Client client) {
+	public Item toEntity(Client client, String imageUrl) {
 		Item item = Item.builder()
 						.client(client)
 						.name(name)
 						.description(description)
 						.price(price)
-						.imageUrl("https://billing-wise-bucket.s3.ap-northeast-2.amazonaws.com/test.png")
+						.imageUrl(imageUrl)
 						.isBasic(true)
 						.build();
 		return item;

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/EditItemDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/EditItemDto.java
@@ -1,0 +1,19 @@
+package site.billingwise.api.serverapi.domain.item.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EditItemDto {
+
+	@NotBlank(message = "상품명은 필수 입력값입니다.")
+	private String name;
+
+	@NotNull(message = "가격은 필수 입력값입니다.")
+	private Long price;
+
+	private String description;
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -22,7 +22,8 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final S3Service s3Service;
 
-    private String itemImageDirectory = "item";
+    public String itemImageDirectory = "item";
+    public String defaultImageUrl = "https://billing-wise-bucket.s3.ap-northeast-2.amazonaws.com/test.png";
 
     // 나중에 지우면 됩니다.
     private final ClientRepository clientRepository;
@@ -32,7 +33,7 @@ public class ItemService {
         // 시큐리티 설정 후 바뀔 겁니다.
         Client client = clientRepository.findById((long) 3).get();
 
-        Item item = createItemDto.toEntity(client);
+        Item item = createItemDto.toEntity(client, defaultImageUrl);
         itemRepository.save(item);
 
         if (multipartFile != null) {
@@ -41,6 +42,7 @@ public class ItemService {
 
     }
 
+    @Transactional
     public void editItem(Long itemId, EditItemDto editItemDto) {
 
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
@@ -49,9 +51,9 @@ public class ItemService {
         item.setPrice(editItemDto.getPrice());
         item.setDescription(editItemDto.getDescription());
 
-        itemRepository.save(item);
     }
 
+    @Transactional
     public void editItemImage(Long itemId, MultipartFile multipartFile) {
 
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
@@ -67,6 +69,16 @@ public class ItemService {
 
     }
 
+    public void deleteItem(Long itemId) {
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+
+        if (!item.getImageUrl().equals(defaultImageUrl)) {
+            s3Service.delete(item.getImageUrl(), itemImageDirectory);
+        }
+
+        itemRepository.delete(item);
+    }
+
     private void uploadImage(Item item, MultipartFile multipartFile) {
 
         if (!multipartFile.getContentType().startsWith("image/")) {
@@ -75,8 +87,6 @@ public class ItemService {
 
         String imageUrl = s3Service.upload(multipartFile, itemImageDirectory);
         item.setImageUrl(imageUrl);
-
-        itemRepository.save(item);
 
     }
 

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -7,6 +7,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
+import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
 import site.billingwise.api.serverapi.domain.item.repository.ItemRepository;
 import site.billingwise.api.serverapi.domain.user.Client;
 import site.billingwise.api.serverapi.domain.user.repository.ClientRepository;
@@ -38,6 +39,17 @@ public class ItemService {
             uploadImage(item, multipartFile);
         }
 
+    }
+
+    public void editItem(Long itemId, EditItemDto editItemDto) {
+
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+
+        item.setName(editItemDto.getName());
+        item.setPrice(editItemDto.getPrice());
+        item.setDescription(editItemDto.getDescription());
+
+        itemRepository.save(item);
     }
 
     public void editItemImage(Long itemId, MultipartFile multipartFile) {

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
@@ -13,6 +13,7 @@ public enum SuccessInfo {
 
     // Item
     ITEM_CREATED("상품 생성이 성공하였습니다."),
+    ITEM_EDITED("상품 정보 수정이 성공하였습니다"),
     ITEM_IMAGE_EDITED("상품 이미지 수정이 성공하였습니다.");
 
     private final Integer code = 200;

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
@@ -12,9 +12,10 @@ public enum SuccessInfo {
     LOGIN("로그인이 성공하였습니다."),
 
     // Item
-    ITEM_CREATED("상품 생성이 성공하였습니다."),
-    ITEM_EDITED("상품 정보 수정이 성공하였습니다"),
-    ITEM_IMAGE_EDITED("상품 이미지 수정이 성공하였습니다.");
+    ITEM_CREATED("상품이 성공적으로 생성되었습니다."),
+    ITEM_EDITED("상품 정보가 성공적으로 수정되었습니다."),
+    ITEM_IMAGE_EDITED("상품 이미지가 성공적으로 수정되었습니다."),
+    ITEM_DELETED("상품이 성공적으로 삭제되었습니다.");
 
     private final Integer code = 200;
     private final String message;

--- a/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
@@ -121,7 +121,6 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 	void editItem() throws Exception {
 
 		// given
-		Long itemId = 3L;
 		String url = "/api/v1/items/{itemId}";
 
 		EditItemDto editItemDto = EditItemDto.builder()
@@ -130,27 +129,27 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 				.description("UPDATED")
 				.build();
 
-		willDoNothing().given(itemService).editItem(itemId, editItemDto);
+		willDoNothing().given(itemService).editItem(anyLong(), eq(editItemDto));
 
 		// when
-		ResultActions result = mockMvc.perform(put(url, itemId)
+		ResultActions result = mockMvc.perform(put(url, ITEM_ID)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(editItemDto)));
 
-        //then
-        result.andExpect(status().isOk()).andDo(document("item/edit-info",
-            requestFields(
-                    fieldWithPath("name").description("상품명 (* required)").type(JsonFieldType.STRING),
-                    fieldWithPath("price").description("상품 가격 (* required)").type(JsonFieldType.NUMBER),
-                    fieldWithPath("description").description("상세 설명").type(JsonFieldType.STRING)
-            )));
+		// then
+		result.andExpect(status().isOk()).andDo(document("item/edit-info",
+				pathParameters(
+						parameterWithName("itemId").description("상품 ID")),
+				requestFields(
+						fieldWithPath("name").description("상품명 (* required)").type(JsonFieldType.STRING),
+						fieldWithPath("price").description("상품 가격 (* required)").type(JsonFieldType.NUMBER),
+						fieldWithPath("description").description("상세 설명").type(JsonFieldType.STRING))));
 	}
 
 	@Test
 	@DisplayName("상품 이미지 수정")
 	void editItemImage() throws Exception {
 		// given
-		Long itemId = 3L;
 		String url = "/api/v1/items/{itemId}/image";
 
 		MockMultipartFile itemImage = new MockMultipartFile(
@@ -160,7 +159,7 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 
 		// when
 		ResultActions result = mockMvc.perform(
-				multipart(url, itemId)
+				multipart(url, ITEM_ID)
 						.file(itemImage)
 						.with(request -> {
 							request.setMethod("PUT");
@@ -174,8 +173,25 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 								parameterWithName("itemId").description("상품 ID")),
 						requestParts(
 								partWithName("image").description("상품 이미지"))));
+	}
 
-		Mockito.verify(itemService, Mockito.times(1)).editItemImage(ArgumentMatchers.eq(itemId),
-				ArgumentMatchers.any());
+	@Test
+	@DisplayName("상품 삭제")
+	void deleteItem() throws Exception {
+
+		// given
+		String url = "/api/v1/items/{itemId}";
+
+		willDoNothing().given(itemService).deleteItem(ITEM_ID);
+
+		// when
+		ResultActions result = mockMvc.perform(
+				delete(url, ITEM_ID));
+
+		// then
+		result.andExpect(status().isOk())
+				.andDo(document("item/delete",
+						pathParameters(
+								parameterWithName("itemId").description("상품 ID"))));
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- [K5P-40] 

## 구현 기능

상품 정보 수정
- 상품 정보 수정 dto, controller, service 작성
- 컨트롤러, 서비스 테스트 코드 작성
- 이전에 작성한 API 변수명 정리

상품 삭제
- 상품 삭제 controller, service 구현 완료
- 상품 삭제 컨트롤러, 서비스 테스트 코드 작성 완료
- 이전 서비스 코드 @transactional 추가

## 참고 사항

[K5P-40]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ