### PR TITLE
[feat] 로그인 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 on:
+  push:
+    branches:
+      - prod
+      - dev
   pull_request:
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // openfeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
     image: redis:7.0.8
     ports:
       - "6379:6379"
-    command: redis-server --port 6379
+    command: redis-server --requirepass 1004 --port 6379

--- a/src/docs/asciidoc/api/auth.adoc
+++ b/src/docs/asciidoc/api/auth.adoc
@@ -13,3 +13,28 @@
 
 operation::auth/register[snippets='http-request,request-fields,http-response']
 
+=== 로그인
+
+이메일과 비밀번호를 통해 로그인을 합니다. 성공 시 액세스 토큰과 리프레시 토큰을 쿠키로 반환합니다.
+
+operation::auth/login[snippets='http-request,request-fields']
+
+==== HTTP response
+
+[source,http,options="nowrap"]
+----
+HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Set-Cookie: access=ACCESS_TOKEN
+Set-Cookie: refresh=REFRESH_TOKEN
+Content-Type: application/json;charset=UTF-8
+Content-Length: 74
+
+{
+    "code": 200,
+    "message": "로그인이 성공하였습니다."
+}
+----
+

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/CustomUserDetails.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/CustomUserDetails.java
@@ -1,0 +1,62 @@
+package site.billingwise.api.serverapi.domain.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import site.billingwise.api.serverapi.domain.user.User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public class CustomUserDetails implements UserDetails {
+
+    private User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    public Long getClientId() {
+        return user.getClient().getId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import site.billingwise.api.serverapi.domain.auth.dto.LoginDto;
 import site.billingwise.api.serverapi.domain.auth.dto.RegisterDto;
 import site.billingwise.api.serverapi.domain.auth.service.AuthService;
 import site.billingwise.api.serverapi.global.response.BaseResponse;
@@ -21,6 +22,13 @@ public class AuthController {
     public BaseResponse register(@Valid @RequestBody RegisterDto registerDto) {
         authService.register(registerDto);
         return new BaseResponse(SuccessInfo.REGISTER);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/login")
+    public BaseResponse login(@Valid @RequestBody LoginDto loginDto) {
+        authService.login(loginDto);
+        return new BaseResponse(SuccessInfo.LOGIN);
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/dto/LoginDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/dto/LoginDto.java
@@ -1,0 +1,21 @@
+package site.billingwise.api.serverapi.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+            message = "비밀번호는 알파벳, 숫자와 특수문자를 모두 포함해야하며 8자리 이상이어야 합니다.")
+    private String password;
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/service/AuthService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -30,7 +31,7 @@ public class AuthService {
     private final ClientRepository clientRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
     private final HttpServletResponse response;
 
@@ -49,8 +50,8 @@ public class AuthService {
         Authentication authentication = null;
 
         try {
-            authentication = authenticationManagerBuilder.getObject()
-                    .authenticate(new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword()));
+            authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword()));
         } catch (Exception ex) {
             log.info(ex.getMessage());
             throw new GlobalException(FailureInfo.WRONG_LOGIN_INFO);

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/service/AuthService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/service/AuthService.java
@@ -1,22 +1,38 @@
 package site.billingwise.api.serverapi.domain.auth.service;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import site.billingwise.api.serverapi.domain.auth.CustomUserDetails;
+import site.billingwise.api.serverapi.domain.auth.dto.LoginDto;
 import site.billingwise.api.serverapi.domain.auth.dto.RegisterDto;
 import site.billingwise.api.serverapi.domain.user.Client;
+import site.billingwise.api.serverapi.domain.user.User;
 import site.billingwise.api.serverapi.domain.user.repository.ClientRepository;
 import site.billingwise.api.serverapi.domain.user.repository.UserRepository;
 import site.billingwise.api.serverapi.global.exception.GlobalException;
+import site.billingwise.api.serverapi.global.jwt.JwtProvider;
 import site.billingwise.api.serverapi.global.response.info.FailureInfo;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final ClientRepository clientRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtProvider jwtProvider;
+    private final HttpServletResponse response;
 
     public void register(RegisterDto registerDto) {
         Client client = clientRepository.findByAuthCode(registerDto.getAuthCode())
@@ -27,5 +43,21 @@ public class AuthService {
         }
         registerDto.setPassword(passwordEncoder.encode(registerDto.getPassword()));
         userRepository.save(registerDto.toEntity(client));
+    }
+
+    public void login(LoginDto loginDto) {
+        Authentication authentication = null;
+
+        try {
+            authentication = authenticationManagerBuilder.getObject()
+                    .authenticate(new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword()));
+        } catch (Exception ex) {
+            log.info(ex.getMessage());
+            throw new GlobalException(FailureInfo.WRONG_LOGIN_INFO);
+        }
+
+        jwtProvider.addAccessToken(authentication, response);
+        jwtProvider.addRefreshToken(authentication, response);
+
     }
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/auth/service/CustomUserDetailService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/auth/service/CustomUserDetailService.java
@@ -1,0 +1,28 @@
+package site.billingwise.api.serverapi.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import site.billingwise.api.serverapi.domain.auth.CustomUserDetails;
+import site.billingwise.api.serverapi.domain.user.User;
+import site.billingwise.api.serverapi.domain.user.repository.UserRepository;
+import site.billingwise.api.serverapi.global.exception.GlobalException;
+import site.billingwise.api.serverapi.global.response.info.FailureInfo;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GlobalException(FailureInfo.NOT_EXIST_USER));
+        return new CustomUserDetails(user);
+    }
+
+
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/contract/Contract.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/contract/Contract.java
@@ -3,6 +3,8 @@ package site.billingwise.api.serverapi.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.invoice.Invoice;
 import site.billingwise.api.serverapi.domain.invoice.InvoiceType;
@@ -17,6 +19,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE contract SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Contract extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/billingwise/api/serverapi/domain/contract/ContractStatus.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/contract/ContractStatus.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -12,6 +14,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE contract_status SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class ContractStatus extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/contract/PaymentType.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/contract/PaymentType.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.invoice.Invoice;
 
@@ -13,6 +15,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE payment_type SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class PaymentType extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/invoice/Invoice.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/invoice/Invoice.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.contract.Contract;
 import site.billingwise.api.serverapi.domain.contract.PaymentType;
@@ -14,6 +16,8 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE invoice SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Invoice extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/invoice/InvoiceType.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/invoice/InvoiceType.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.contract.Contract;
 
@@ -13,6 +15,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE invoice_type SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class InvoiceType extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/invoice/PaymentStatus.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/invoice/PaymentStatus.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -12,6 +14,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE payment_status SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class PaymentStatus extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.item;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.contract.Contract;
 import site.billingwise.api.serverapi.domain.user.Client;
@@ -14,6 +16,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE item SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Item extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/ConsentAccount.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/ConsentAccount.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 @Entity
@@ -9,6 +11,8 @@ import site.billingwise.api.serverapi.domain.common.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE consent_account SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class ConsentAccount extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/Member.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/Member.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.contract.Contract;
 import site.billingwise.api.serverapi.domain.user.Client;
@@ -17,6 +19,8 @@ import java.util.List;
 @Table(uniqueConstraints = {
     @UniqueConstraint(columnNames = {"client_id", "email"})
 })
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/payment/Payment.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/payment/Payment.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.invoice.Invoice;
 
@@ -10,6 +12,8 @@ import site.billingwise.api.serverapi.domain.invoice.Invoice;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE payment SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Payment extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/payment/PaymentAccount.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/payment/PaymentAccount.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 @Entity
@@ -9,6 +11,8 @@ import site.billingwise.api.serverapi.domain.common.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE payment_account SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class PaymentAccount extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/payment/PaymentCard.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/payment/PaymentCard.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 @Entity
@@ -9,6 +11,8 @@ import site.billingwise.api.serverapi.domain.common.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE payment_card SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class PaymentCard extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/user/Client.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/user/Client.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.member.Member;
@@ -14,6 +16,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE client SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class Client extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/user/User.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/user/User.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 
 @Entity
@@ -9,6 +11,8 @@ import site.billingwise.api.serverapi.domain.common.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SQLDelete(sql = "UPDATE user SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/site/billingwise/api/serverapi/domain/user/repository/UserRepository.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/user/repository/UserRepository.java
@@ -4,6 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.billingwise.api.serverapi.domain.user.Client;
 import site.billingwise.api.serverapi.domain.user.User;
 
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long>  {
     boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
+
+
 }

--- a/src/main/java/site/billingwise/api/serverapi/global/config/RedisConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package site.billingwise.api.serverapi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<Long, String> redisTemplate() {
+        RedisTemplate<Long, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
 

--- a/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
@@ -3,11 +3,15 @@ package site.billingwise.api.serverapi.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import site.billingwise.api.serverapi.global.jwt.JwtProvider;
 
 import java.util.Collections;
 
@@ -16,31 +20,42 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtProvider jwtProvider;
+//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+//    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
     @Bean
     public BCryptPasswordEncoder bcryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    private static final String[] WHITE_LIST = {
+        "/actuator/health",
+        "/api/v1/**"
+    };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
                 .csrf((auth) -> auth.disable());
-
         http
                 .formLogin((auth) -> auth.disable());
-
         http
                 .httpBasic((auth) -> auth.disable());
-
-        http
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/actuator/health", "/api/v1/**").permitAll()
-                        .anyRequest().authenticated());
-
         http
                 .sessionManagement((session) -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+//        http
+//                .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+//        http
+//                .exceptionHandling((exception) -> exception
+//                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+//                        .accessDeniedHandler(jwtAccessDeniedHandler)))
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(WHITE_LIST).permitAll()
+                        .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -27,6 +28,11 @@ public class SecurityConfig {
     @Bean
     public BCryptPasswordEncoder bcryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     private static final String[] WHITE_LIST = {

--- a/src/main/java/site/billingwise/api/serverapi/global/config/WebConfig.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/config/WebConfig.java
@@ -15,7 +15,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://billingwise.site",
                         "https://*.billingwise.site"
                         )
-                .allowedMethods("*");
+                .allowedMethods("*")
+                .allowCredentials(true);
     }
 }
 

--- a/src/main/java/site/billingwise/api/serverapi/global/jwt/JwtProvider.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/jwt/JwtProvider.java
@@ -1,0 +1,145 @@
+package site.billingwise.api.serverapi.global.jwt;
+
+import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.security.Keys;
+import site.billingwise.api.serverapi.domain.auth.CustomUserDetails;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtProvider {
+    private static final Long ACCESS_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60;    // 1hour
+    private static final Long REFRESH_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60 * 24 * 7;  // 1week
+    private final SecretKey secretKey;
+    private static final String AUTHORITIES_KEY = "role";
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final UserDetailsService userDetailsService;
+
+    public JwtProvider(@Value("${app.auth.token.secret-key}") String secret,
+                       UserDetailsService userDetailsService,
+                       RefreshTokenRedisRepository refreshTokenRedisRepository) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.userDetailsService = userDetailsService;
+        this.refreshTokenRedisRepository = refreshTokenRedisRepository;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH);
+
+        CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+
+        Long userId = user.getId();
+        String role = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .signWith(secretKey)
+                .setSubject(String.valueOf(userId))
+                .claim(AUTHORITIES_KEY, role)
+                .setIssuer("billingwise")
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_LENGTH);
+
+        return Jwts.builder()
+                .signWith(secretKey)
+                .setIssuer("billingwise")
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public void addAccessToken(Authentication authentication, HttpServletResponse response) {
+        String accessToken = createAccessToken(authentication);
+
+        ResponseCookie cookie = ResponseCookie.from("access", accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(ACCESS_TOKEN_EXPIRE_LENGTH / 1000)
+                .path("/")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void addRefreshToken(Authentication authentication, HttpServletResponse response) {
+        String refreshToken = createRefreshToken();
+
+        saveRefreshToken(authentication, refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refresh", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(REFRESH_TOKEN_EXPIRE_LENGTH / 1000)
+                .path("/")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    private void saveRefreshToken(Authentication authentication, String refreshToken) {
+        CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+
+        refreshTokenRedisRepository.save(RefreshToken.builder()
+                .id(user.getId())
+                .token(refreshToken)
+                .expiredTime(REFRESH_TOKEN_EXPIRE_LENGTH)
+                .build());
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public Boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT token.");
+        } catch (MalformedJwtException e) {
+            log.info("Malformed Jwt token.");
+        } catch (Exception e) {
+            log.info(e.getMessage());
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(secretKey).build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/site/billingwise/api/serverapi/global/jwt/RefreshToken.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/jwt/RefreshToken.java
@@ -1,0 +1,21 @@
+package site.billingwise.api.serverapi.global.jwt;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@RedisHash(value = "id")
+public class RefreshToken {
+
+    @Id
+    private Long id;
+    private String token;
+
+    @TimeToLive
+    private long expiredTime;
+}

--- a/src/main/java/site/billingwise/api/serverapi/global/jwt/RefreshTokenRedisRepository.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/jwt/RefreshTokenRedisRepository.java
@@ -1,0 +1,9 @@
+package site.billingwise.api.serverapi.global.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
@@ -14,6 +14,8 @@ public enum FailureInfo {
     // auth
     UNAUTHORIZED_AUTH_CODE(401, "유효하지 않은 인증 코드입니다."),
     ALREADY_EXIST_USER(409, "이미 존재하는 사용자입니다."),
+    WRONG_LOGIN_INFO(401, "잘못된 이메일 혹은 비밀번호입니다."),
+    NOT_EXIST_USER(404, "존재하지 않는 사용자입니다."),
 
     // image
     INVALID_IMAGE(400, "사진 파일이 유효하지 않습니다.");

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+      password:
+
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -30,4 +32,4 @@ spring:
 app:
   auth:
     token:
-      secret-key: zhtkgytjdqlfflddhkdlwm
+      secret-key: jwtsecretkeyforlocaljwtsecretkeyforlocaljwtsecretkeyforlocaljwtsecretkeyforlocaljwtsecretkeyforlocaljwtsecretkeyforlocal

--- a/src/test/java/site/billingwise/api/serverapi/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/auth/controller/AuthControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 import site.billingwise.api.serverapi.docs.restdocs.AbstractRestDocsTests;
 import site.billingwise.api.serverapi.domain.auth.controller.AuthController;
+import site.billingwise.api.serverapi.domain.auth.dto.LoginDto;
 import site.billingwise.api.serverapi.domain.auth.dto.RegisterDto;
 import site.billingwise.api.serverapi.domain.auth.service.AuthService;
 
@@ -73,5 +74,31 @@ public class AuthControllerTest extends AbstractRestDocsTests {
                     fieldWithPath("name").description("이름 (* required)").type(JsonFieldType.STRING),
                     fieldWithPath("phone").description("전화번호 (* required)").type(JsonFieldType.STRING)
             )));
+    }
+
+    @Test
+    @DisplayName("로그인")
+    void login() throws Exception {
+        String url = "/api/v1/auth/login";
+
+        LoginDto loginDto = LoginDto.builder()
+                .email("test@gmail.com")
+                .password("test1234!")
+                .build();
+
+        // given
+        willDoNothing().given(authService).login(loginDto);
+
+        // when
+        ResultActions result = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginDto)));
+
+        //then
+        result.andExpect(status().isOk()).andDo(document("auth/login",
+                requestFields(
+                        fieldWithPath("email").description("이메일 (* required)").type(JsonFieldType.STRING),
+                        fieldWithPath("password").description("비밀번호 (* required)").type(JsonFieldType.STRING)
+                )));
     }
 }

--- a/src/test/java/site/billingwise/api/serverapi/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/auth/service/AuthServiceTest.java
@@ -129,7 +129,8 @@ class AuthServiceTest {
                 .password("test1234!")
                 .build();
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenReturn(authentication);
 
@@ -148,7 +149,7 @@ class AuthServiceTest {
                 .build();
 
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenThrow(new AuthenticationException("Bad credentials") {});
+                .thenThrow(new AuthenticationException("Bad credentials") { });
 
         GlobalException exception = assertThrows(GlobalException.class, () -> authService.login(loginDto));
         assertEquals(FailureInfo.WRONG_LOGIN_INFO, exception.getFailureInfo());

--- a/src/test/java/site/billingwise/api/serverapi/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/auth/service/AuthServiceTest.java
@@ -1,17 +1,23 @@
 package site.billingwise.api.serverapi.domain.auth.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import site.billingwise.api.serverapi.domain.auth.dto.LoginDto;
 import site.billingwise.api.serverapi.domain.auth.dto.RegisterDto;
-import site.billingwise.api.serverapi.domain.auth.service.AuthService;
 import site.billingwise.api.serverapi.domain.user.Client;
 import site.billingwise.api.serverapi.domain.user.repository.ClientRepository;
 import site.billingwise.api.serverapi.domain.user.repository.UserRepository;
 import site.billingwise.api.serverapi.global.exception.GlobalException;
+import site.billingwise.api.serverapi.global.jwt.JwtProvider;
 import site.billingwise.api.serverapi.global.response.info.FailureInfo;
 
 import java.util.Optional;
@@ -31,6 +37,15 @@ class AuthServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private HttpServletResponse response;
 
     @InjectMocks
     private AuthService authService;
@@ -105,5 +120,41 @@ class AuthServiceTest {
         verify(userRepository, times(1)).existsByEmail(anyString());
         verify(passwordEncoder, never()).encode(anyString());
         verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void login_Success() {
+        LoginDto loginDto = LoginDto.builder()
+                .email("test@gmail.com")
+                .password("test1234!")
+                .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+
+        authService.login(loginDto);
+
+        verify(authenticationManager, times(1)).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(jwtProvider, times(1)).addAccessToken(authentication, response);
+        verify(jwtProvider, times(1)).addRefreshToken(authentication, response);
+    }
+
+    @Test
+    void login_Failure() {
+        LoginDto loginDto = LoginDto.builder()
+                .email("test@gmail.com")
+                .password("wrong_password")
+                .build();
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenThrow(new AuthenticationException("Bad credentials") {});
+
+        GlobalException exception = assertThrows(GlobalException.class, () -> authService.login(loginDto));
+        assertEquals(FailureInfo.WRONG_LOGIN_INFO, exception.getFailureInfo());
+
+        verify(authenticationManager, times(1)).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(jwtProvider, never()).addAccessToken(any(Authentication.class), any(HttpServletResponse.class));
+        verify(jwtProvider, never()).addRefreshToken(any(Authentication.class), any(HttpServletResponse.class));
     }
 }


### PR DESCRIPTION
## 관련 이슈

- [K5P-44]

## 구현 기능

- 로그인 API 구현
- 로그인 API 테스트
- 로그인 서비스 함수 테스트
- 로그인 성공 시 액세스 토큰과 리프레시 토큰을 쿠키로 발급
- 리프레시 토큰 레디스에 저장

## 참고 사항
- javascript로 로그인 API 요청 시 credentials: 'include' 설정해야 쿠키 발급됨

[K5P-44]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ