### PR TITLE
[feat] 상품 상세 조회 API

### DIFF
--- a/src/docs/asciidoc/api/item.adoc
+++ b/src/docs/asciidoc/api/item.adoc
@@ -42,7 +42,7 @@ operation::item/delete[snippets='http-request,path-parameters,http-response']
 operation::item/get[snippets='http-request,path-parameters,http-response,response-fields']
 
 
-=== 상품 상세 조회
+=== 상품 목록 조회
 
 상품 상세 정보를 조회합니다.
 

--- a/src/docs/asciidoc/api/item.adoc
+++ b/src/docs/asciidoc/api/item.adoc
@@ -35,3 +35,10 @@ operation::item/edit-image[snippets='http-request,path-parameters,request-parts,
 operation::item/delete[snippets='http-request,path-parameters,http-response']
 
 
+=== 상품 상세 조회
+
+상품 상세 정보를 조회합니다.
+
+operation::item/get[snippets='http-request,path-parameters,http-response,response-fields']
+
+

--- a/src/docs/asciidoc/api/item.adoc
+++ b/src/docs/asciidoc/api/item.adoc
@@ -42,3 +42,10 @@ operation::item/delete[snippets='http-request,path-parameters,http-response']
 operation::item/get[snippets='http-request,path-parameters,http-response,response-fields']
 
 
+=== 상품 상세 조회
+
+상품 상세 정보를 조회합니다.
+
+operation::item/get[snippets='http-request,http-response,response-fields']
+
+

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import site.billingwise.api.serverapi.domain.common.BaseEntity;
 import site.billingwise.api.serverapi.domain.contract.Contract;
+import site.billingwise.api.serverapi.domain.item.dto.response.GetItemDto;
 import site.billingwise.api.serverapi.domain.user.Client;
 
 import java.util.ArrayList;
@@ -62,5 +63,20 @@ public class Item extends BaseEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public GetItemDto toDto() {
+        GetItemDto getItemDto = GetItemDto.builder()
+                .id(id)
+                .name(name)
+                .price(price)
+                .description(description)
+                .imageUrl(imageUrl)
+                .createdAt(this.getCreatedAt())
+                .updatedAt(this.getUpdatedAt())
+                .contractCount(contractCount)
+                .build();
+
+        return getItemDto;
     }
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/Item.java
@@ -9,6 +9,8 @@ import site.billingwise.api.serverapi.domain.user.Client;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.Formula;
+
 @Entity
 @Getter
 @Builder
@@ -42,6 +44,9 @@ public class Item extends BaseEntity {
 
     @OneToMany(mappedBy = "item")
     private List<Contract> contractList = new ArrayList<>();
+
+    @Formula("(SELECT COUNT(*) FROM contract ct WHERE ct.item_id = item_id)")
+    private Long contractCount;
 
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
@@ -11,12 +11,16 @@ import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
 import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
+import site.billingwise.api.serverapi.domain.item.dto.response.GetItemDto;
 import site.billingwise.api.serverapi.domain.item.service.ItemService;
 import site.billingwise.api.serverapi.global.response.BaseResponse;
+import site.billingwise.api.serverapi.global.response.DataResponse;
 import site.billingwise.api.serverapi.global.response.info.SuccessInfo;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -41,7 +45,7 @@ public class ItemController {
 
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{itemId}")
-    public BaseResponse editItem(@PathVariable Long itemId, @Valid @RequestBody EditItemDto editItemDto) {
+    public BaseResponse editItem(@PathVariable("itemId") Long itemId, @Valid @RequestBody EditItemDto editItemDto) {
 
         itemService.editItem(itemId, editItemDto);
 
@@ -50,7 +54,7 @@ public class ItemController {
 
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{itemId}/image")
-    public BaseResponse editItemImage(@PathVariable Long itemId,
+    public BaseResponse editItemImage(@PathVariable("itemId") Long itemId,
             @RequestPart(name = "image", required = false) MultipartFile multipartFile) {
 
         itemService.editItemImage(itemId, multipartFile);
@@ -60,11 +64,20 @@ public class ItemController {
 
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/{itemId}")
-    public BaseResponse deleteItem(@PathVariable Long itemId) {
+    public BaseResponse deleteItem(@PathVariable("itemId") Long itemId) {
 
         itemService.deleteItem(itemId);
 
         return new BaseResponse(SuccessInfo.ITEM_DELETED);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{itemId}")
+    public DataResponse<GetItemDto> getItem(@PathVariable("itemId") Long itemId) {
+
+        GetItemDto getItemDto = itemService.getItem(itemId);
+        
+        return new DataResponse<>(SuccessInfo.ITEM_LOADED, getItemDto);
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/controller/ItemController.java
@@ -1,13 +1,14 @@
 package site.billingwise.api.serverapi.domain.item.controller;
 
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Pageable;
 
 import jakarta.validation.Valid;
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
 import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
@@ -17,8 +18,9 @@ import site.billingwise.api.serverapi.global.response.BaseResponse;
 import site.billingwise.api.serverapi.global.response.DataResponse;
 import site.billingwise.api.serverapi.global.response.info.SuccessInfo;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,7 +39,6 @@ public class ItemController {
     @PostMapping()
     public BaseResponse createItem(@Valid @RequestPart(name = "data") CreateItemDto createItemDto,
             @RequestPart(name = "image", required = false) MultipartFile multipartFile) {
-
         itemService.createItem(createItemDto, multipartFile);
 
         return new BaseResponse(SuccessInfo.ITEM_CREATED);
@@ -46,7 +47,6 @@ public class ItemController {
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{itemId}")
     public BaseResponse editItem(@PathVariable("itemId") Long itemId, @Valid @RequestBody EditItemDto editItemDto) {
-
         itemService.editItem(itemId, editItemDto);
 
         return new BaseResponse(SuccessInfo.ITEM_EDITED);
@@ -56,7 +56,6 @@ public class ItemController {
     @PutMapping("/{itemId}/image")
     public BaseResponse editItemImage(@PathVariable("itemId") Long itemId,
             @RequestPart(name = "image", required = false) MultipartFile multipartFile) {
-
         itemService.editItemImage(itemId, multipartFile);
 
         return new BaseResponse(SuccessInfo.ITEM_IMAGE_EDITED);
@@ -65,7 +64,6 @@ public class ItemController {
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/{itemId}")
     public BaseResponse deleteItem(@PathVariable("itemId") Long itemId) {
-
         itemService.deleteItem(itemId);
 
         return new BaseResponse(SuccessInfo.ITEM_DELETED);
@@ -76,8 +74,18 @@ public class ItemController {
     public DataResponse<GetItemDto> getItem(@PathVariable("itemId") Long itemId) {
 
         GetItemDto getItemDto = itemService.getItem(itemId);
-        
+
         return new DataResponse<>(SuccessInfo.ITEM_LOADED, getItemDto);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping()
+    public DataResponse<List<GetItemDto>> getItemList(@RequestParam(name = "name", required = false) String itemName,
+            Pageable pageable) {
+
+        List<GetItemDto> getItemDtoList = itemService.getItemList(itemName, pageable);
+
+        return new DataResponse<>(SuccessInfo.ITEM_LOADED, getItemDtoList);
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/CreateItemDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/CreateItemDto.java
@@ -2,13 +2,17 @@ package site.billingwise.api.serverapi.domain.item.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.user.Client;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CreateItemDto {
 
 	@NotBlank(message = "상품명은 필수 입력값입니다.")

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/EditItemDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/dto/request/EditItemDto.java
@@ -2,11 +2,15 @@ package site.billingwise.api.serverapi.domain.item.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class EditItemDto {
 
 	@NotBlank(message = "상품명은 필수 입력값입니다.")

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/dto/response/GetItemDto.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/dto/response/GetItemDto.java
@@ -1,0 +1,21 @@
+package site.billingwise.api.serverapi.domain.item.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetItemDto {
+
+    private Long id;
+    private String name;
+    private String description;
+    private Long price;
+    private String imageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long contractCount;
+
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/repository/ItemRepository.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/repository/ItemRepository.java
@@ -1,5 +1,7 @@
 package site.billingwise.api.serverapi.domain.item.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import site.billingwise.api.serverapi.domain.item.Item;
@@ -8,4 +10,8 @@ import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 	Optional<Item> findById(Long id);
+
+	Page<Item> findAllByClientId(Pageable pageable, Long clientId);
+
+	Page<Item> findAllByNameContainingIgnoreCase(String itemName, Pageable pageable);
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -33,7 +33,9 @@ public class ItemService {
 
     @Transactional
     public void createItem(CreateItemDto createItemDto, MultipartFile multipartFile) {
-        Client client = clientRepository.findById(getClientId()).orElseThrow(() -> new GlobalException(FailureInfo.CLIENT_NOT_FOUND));
+        Client client = clientRepository.findById(getClientId()).orElseThrow(() -> 
+            new GlobalException(FailureInfo.CLIENT_NOT_FOUND)
+        );
 
         Item item = createItemDto.toEntity(client, defaultImageUrl);
         itemRepository.save(item);
@@ -120,7 +122,7 @@ public class ItemService {
 
     private Long getClientId() {
         // 스프링 시큐리티를 활용한 로직 추가
-        return 3l;
+        return 3L;
     }
 
     private void isOwner(Item item, Long clientId) {

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -1,9 +1,13 @@
 package site.billingwise.api.serverapi.domain.item.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
@@ -21,18 +25,15 @@ import site.billingwise.api.serverapi.global.service.S3Service;
 public class ItemService {
 
     private final ItemRepository itemRepository;
+    private final ClientRepository clientRepository;
     private final S3Service s3Service;
 
     public String itemImageDirectory = "item";
     public String defaultImageUrl = "https://billing-wise-bucket.s3.ap-northeast-2.amazonaws.com/test.png";
 
-    // 나중에 지우면 됩니다.
-    private final ClientRepository clientRepository;
-
     @Transactional
     public void createItem(CreateItemDto createItemDto, MultipartFile multipartFile) {
-        // 시큐리티 설정 후 바뀔 겁니다.
-        Client client = clientRepository.findById((long) 3).get();
+        Client client = clientRepository.findById(getClientId()).orElseThrow(() -> new GlobalException(FailureInfo.CLIENT_NOT_FOUND));
 
         Item item = createItemDto.toEntity(client, defaultImageUrl);
         itemRepository.save(item);
@@ -45,8 +46,8 @@ public class ItemService {
 
     @Transactional
     public void editItem(Long itemId, EditItemDto editItemDto) {
-
-        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.ITEM_NOT_FOUND));
+        isOwner(item, getClientId());
 
         item.setName(editItemDto.getName());
         item.setPrice(editItemDto.getPrice());
@@ -56,8 +57,9 @@ public class ItemService {
 
     @Transactional
     public void editItemImage(Long itemId, MultipartFile multipartFile) {
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.ITEM_NOT_FOUND));
+        isOwner(item, getClientId());
 
-        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
         String prevImageUrl = item.getImageUrl();
 
         if (multipartFile != null) {
@@ -71,7 +73,8 @@ public class ItemService {
     }
 
     public void deleteItem(Long itemId) {
-        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.ITEM_NOT_FOUND));
+        isOwner(item, getClientId());
 
         if (!item.getImageUrl().equals(defaultImageUrl)) {
             s3Service.delete(item.getImageUrl(), itemImageDirectory);
@@ -80,21 +83,28 @@ public class ItemService {
         itemRepository.delete(item);
     }
 
+    @Transactional(readOnly = true)
     public GetItemDto getItem(Long itemId) {
-        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.ITEM_NOT_FOUND));
+        isOwner(item, getClientId());
 
-        GetItemDto getItemDto = GetItemDto.builder()
-                .id(item.getId())
-                .name(item.getName())
-                .price(item.getPrice())
-                .description(item.getDescription())
-                .imageUrl(item.getImageUrl())
-                .createdAt(item.getCreatedAt())
-                .updatedAt(item.getUpdatedAt())
-                .contractCount(item.getContractCount())
-                .build();
+        GetItemDto getItemDto = item.toDto();
 
         return getItemDto;
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetItemDto> getItemList(String itemName, Pageable pageable) {
+        Page<Item> itemList = null;
+
+        if (itemName == null) {
+            itemList = itemRepository.findAllByClientId(pageable, getClientId());
+        } else {
+            itemList = itemRepository.findAllByNameContainingIgnoreCase(itemName, pageable);
+        }
+
+        List<GetItemDto> getItemDtoList = itemList.map(item -> item.toDto()).getContent();
+        return getItemDtoList;
     }
 
     private void uploadImage(Item item, MultipartFile multipartFile) {
@@ -106,6 +116,17 @@ public class ItemService {
         String imageUrl = s3Service.upload(multipartFile, itemImageDirectory);
         item.setImageUrl(imageUrl);
 
+    }
+
+    private Long getClientId() {
+        // 스프링 시큐리티를 활용한 로직 추가
+        return 3l;
+    }
+
+    private void isOwner(Item item, Long clientId) {
+        if (item.getClient().getId() != clientId) {
+            throw new GlobalException(FailureInfo.ITEM_ACCESS_DENIED);
+        }
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
 import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
+import site.billingwise.api.serverapi.domain.item.dto.response.GetItemDto;
 import site.billingwise.api.serverapi.domain.item.repository.ItemRepository;
 import site.billingwise.api.serverapi.domain.user.Client;
 import site.billingwise.api.serverapi.domain.user.repository.ClientRepository;
@@ -77,6 +78,23 @@ public class ItemService {
         }
 
         itemRepository.delete(item);
+    }
+
+    public GetItemDto getItem(Long itemId) {
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new GlobalException(FailureInfo.NO_ITEM));
+
+        GetItemDto getItemDto = GetItemDto.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .price(item.getPrice())
+                .description(item.getDescription())
+                .imageUrl(item.getImageUrl())
+                .createdAt(item.getCreatedAt())
+                .updatedAt(item.getUpdatedAt())
+                .contractCount(item.getContractCount())
+                .build();
+
+        return getItemDto;
     }
 
     private void uploadImage(Item item, MultipartFile multipartFile) {

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
@@ -14,12 +14,14 @@ public enum FailureInfo {
     // auth
     UNAUTHORIZED_AUTH_CODE(401, "유효하지 않은 인증 코드입니다."),
     ALREADY_EXIST_USER(409, "이미 존재하는 사용자입니다."),
+    CLIENT_NOT_FOUND(401, "존재하지 않는 고객입니다."),
 
     // image
     INVALID_IMAGE(400, "사진 파일이 유효하지 않습니다."),
     
     // item
-    NO_ITEM(400, "해당 상품은 존재하지 않습니다.");
+    ITEM_NOT_FOUND(400, "해당 상품은 존재하지 않습니다."),
+    ITEM_ACCESS_DENIED(403, "접근 권한이 없는 상품입니다.");
 
     private final Integer code;
     private final String message;

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/SuccessInfo.java
@@ -15,7 +15,8 @@ public enum SuccessInfo {
     ITEM_CREATED("상품이 성공적으로 생성되었습니다."),
     ITEM_EDITED("상품 정보가 성공적으로 수정되었습니다."),
     ITEM_IMAGE_EDITED("상품 이미지가 성공적으로 수정되었습니다."),
-    ITEM_DELETED("상품이 성공적으로 삭제되었습니다.");
+    ITEM_DELETED("상품이 성공적으로 삭제되었습니다."),
+    ITEM_LOADED("상품 정보를 성공적으로 불러왔습니다.");
 
     private final Integer code = 200;
     private final String message;

--- a/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
@@ -257,7 +257,7 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 
 
 	@Test
-    @DisplayName("상품 목록 조회")
+	@DisplayName("상품 목록 조회")
     void getItemList() throws Exception {
         // given
         String url = "/api/v1/items";

--- a/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/item/controller/ItemControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -26,21 +27,29 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import static org.mockito.ArgumentMatchers.any;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -50,11 +59,13 @@ import site.billingwise.api.serverapi.docs.restdocs.AbstractRestDocsTests;
 import site.billingwise.api.serverapi.domain.auth.dto.RegisterDto;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
 import site.billingwise.api.serverapi.domain.item.dto.request.EditItemDto;
+import site.billingwise.api.serverapi.domain.item.dto.response.GetItemDto;
 import site.billingwise.api.serverapi.domain.item.service.ItemService;
 import site.billingwise.api.serverapi.domain.user.repository.ClientRepository;
 import site.billingwise.api.serverapi.global.service.S3Service;
 
 @WebMvcTest(ItemController.class)
+@AutoConfigureMockMvc
 public class ItemControllerTest extends AbstractRestDocsTests {
 
 	static final Long ITEM_ID = 3L;
@@ -193,5 +204,50 @@ public class ItemControllerTest extends AbstractRestDocsTests {
 				.andDo(document("item/delete",
 						pathParameters(
 								parameterWithName("itemId").description("상품 ID"))));
+	}
+
+	@Test
+	@DisplayName("상품 상세 조회")
+	void getItem() throws Exception {
+		// given
+		String url = "/api/v1/items/{itemId}";
+
+		GetItemDto getItemDto = GetItemDto.builder()
+				.id(1L)
+				.name("Name")
+				.description("Item Description")
+				.price(1000L)
+				.imageUrl("http://example.com/image.jpg")
+				.createdAt(LocalDateTime.now())
+				.updatedAt(LocalDateTime.now())
+				.contractCount(5L)
+				.build();
+
+		given(itemService.getItem(anyLong())).willReturn(getItemDto);
+
+		// when
+		ResultActions result = mockMvc.perform(get(url, 1L));
+
+		// then
+		result.andExpect(status().isOk())
+				.andDo(document("item/get",
+						pathParameters(
+								parameterWithName("itemId").description("상품ID")),
+						responseFields(
+								fieldWithPath("code").description("응답 코드").type(JsonFieldType.NUMBER),
+								fieldWithPath("message").description("응답 메시지").type(JsonFieldType.STRING),
+								fieldWithPath("data.id").description("상품 ID").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.name").description("상품명").type(JsonFieldType.STRING),
+								fieldWithPath("data.description").description("상품 설명")
+										.type(JsonFieldType.STRING),
+								fieldWithPath("data.price").description("상품 가격").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.imageUrl").description("상품 이미지 URL")
+										.type(JsonFieldType.STRING),
+								fieldWithPath("data.createdAt").description("상품 생성일")
+										.type(JsonFieldType.STRING),
+								fieldWithPath("data.updatedAt").description("상품 정보 수정일")
+										.type(JsonFieldType.STRING),
+								fieldWithPath("data.contractCount").description("관련 계약수")
+										.type(JsonFieldType.NUMBER))));
 	}
 }

--- a/src/test/java/site/billingwise/api/serverapi/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/item/service/ItemServiceTest.java
@@ -230,7 +230,7 @@ class ItemServiceTest {
 
 		// then
 		verify(itemRepository).findById(itemId);
-		assert (exception.getFailureInfo().equals(FailureInfo.NO_ITEM));
+		assert (exception.getFailureInfo().equals(FailureInfo.ITEM_NOT_FOUND));
 	}
 
 	@Test
@@ -327,7 +327,7 @@ class ItemServiceTest {
 		GlobalException exception = assertThrows(GlobalException.class, () -> itemService.getItem(itemId));
 
 		// then
-		assertThat(exception.getFailureInfo()).isEqualTo(FailureInfo.NO_ITEM);
+		assertThat(exception.getFailureInfo()).isEqualTo(FailureInfo.ITEM_NOT_FOUND);
 
 		verify(itemRepository).findById(itemId);
 	}


### PR DESCRIPTION
## 관련 이슈

- [K5P-40] 

## 구현 기능

상품 상세 조회 API
- 상품 상세 조회 dto, controller, service 작성
- item entity에 계약 건수 가상 컬럼 추가
- controller, service 테스트 코드 작성

상품 목록 조회 API
- 상품 목록 조회 controller, service, repository 구현
- 이전에 구현했던 api에 고객 검증 로직 추가

## 참고 사항

[K5P-40]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ