### PR TITLE
[fix] 회원 api 수정

### DIFF
--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -11,14 +11,14 @@
 
 회원을 생성합니다.
 
-operation::member/create[snippets='request-cookies,http-request,request-fields,http-response']
+operation::member/create[snippets='request-cookies,http-request,request-fields,http-response,response-fields']
 
 
 === 회원 수정
 
 회원 정보를 수정합니다.
 
-operation::member/edit[snippets='request-cookies,http-request,path-parameters,request-fields,http-response']
+operation::member/edit[snippets='request-cookies,http-request,path-parameters,request-fields,http-response,response-fields']
 
 
 === 회원 삭제
@@ -46,6 +46,7 @@ operation::member/get-list[snippets='request-cookies,http-request,http-response,
 
 엑셀 파일을 활용하여 회원 정보를 대량 등록합니다.
 
-operation::member/bulk-register[snippets='request-cookies,http-request,http-response,response-fields']
+operation::member/bulk-register/success[snippets='request-cookies,http-request,http-response,response-fields']
+operation::member/bulk-register/fail[snippets='request-cookies,http-request,http-response,response-fields']
 
 

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/Member.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/Member.java
@@ -2,6 +2,8 @@ package site.billingwise.api.serverapi.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -50,8 +52,8 @@ public class Member extends BaseEntity {
     @Column(length = 20, nullable = false)
     private String phone;
 
-//    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
-//    private ConsentAccount consentAccount;
+    @Formula("(SELECT COUNT(*) FROM contract ct WHERE ct.member_id = member_id and ct.is_deleted = false)")
+    private Long contractCount;
 
     @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
     private Set<Contract> contractList;

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/controller/MemberController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/controller/MemberController.java
@@ -1,16 +1,20 @@
 package site.billingwise.api.serverapi.domain.member.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import lombok.RequiredArgsConstructor;
+import site.billingwise.api.serverapi.domain.contract.dto.request.CreateContractDto;
 import site.billingwise.api.serverapi.domain.member.dto.request.CreateMemberDto;
 import site.billingwise.api.serverapi.domain.member.dto.response.CreateBulkResultDto;
 import site.billingwise.api.serverapi.domain.member.dto.response.GetMemberDto;
 import site.billingwise.api.serverapi.domain.member.service.MemberService;
 import site.billingwise.api.serverapi.global.response.BaseResponse;
 import site.billingwise.api.serverapi.global.response.DataResponse;
+import site.billingwise.api.serverapi.global.response.info.FailureInfo;
 import site.billingwise.api.serverapi.global.response.info.SuccessInfo;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -36,19 +40,19 @@ public class MemberController {
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping()
-    public BaseResponse createMember(@Valid @RequestBody CreateMemberDto createMemberDto) {
-        memberService.createMember(createMemberDto);
+    public DataResponse<Long> createMember(@Valid @RequestBody CreateMemberDto createMemberDto) {
+        Long memberId = memberService.createMember(createMemberDto);
 
-        return new BaseResponse(SuccessInfo.MEMBER_CREATED);
+        return new DataResponse<>(SuccessInfo.MEMBER_CREATED, memberId);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{memberId}")
-    public BaseResponse editMember(@PathVariable("memberId") Long memberId,
+    public DataResponse<GetMemberDto> editMember(@PathVariable("memberId") Long memberId,
             @Valid @RequestBody CreateMemberDto createMemberDto) {
-        memberService.editMember(memberId, createMemberDto);
+        GetMemberDto getMemberDto = memberService.editMember(memberId, createMemberDto);
 
-        return new BaseResponse(SuccessInfo.MEMBER_UPDATED);
+        return new DataResponse<>(SuccessInfo.MEMBER_UPDATED, getMemberDto);
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -81,10 +85,16 @@ public class MemberController {
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/bulk-register")
-    public DataResponse<CreateBulkResultDto> createMemberBulk(@RequestPart("file") MultipartFile file) {
+    public DataResponse<?> createMemberBulk(@RequestPart("file") MultipartFile file) {
         CreateBulkResultDto createBulkResultDto = memberService.createMemberBulk(file);
 
-        return new DataResponse<>(SuccessInfo.FILE_UPLOADED, createBulkResultDto);
+        if (createBulkResultDto.isSuccess()) {
+            List<CreateMemberDto> createMemberDtoList = createBulkResultDto.getMemberList();
+            return new DataResponse<>(SuccessInfo.CONTRACT_CREATED, createMemberDtoList);
+        } else {
+            List<String> errorList = createBulkResultDto.getErrorList();
+            return new DataResponse<>(FailureInfo.INVALID_FILE, errorList);
+        }
     }
 
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/controller/MemberController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package site.billingwise.api.serverapi.domain.member.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -72,8 +70,11 @@ public class MemberController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping()
     public DataResponse<Page<GetMemberDto>> getMemberList(
-            @RequestParam(name = "name", required = false) String memberName, Pageable pageable) {
-        Page<GetMemberDto> getMemberDtoList = memberService.getMemberList(memberName, pageable);
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "email", required = false) String email,
+            @RequestParam(name = "phone", required = false) String phone,
+            Pageable pageable) {
+        Page<GetMemberDto> getMemberDtoList = memberService.getMemberList(name, email, phone, pageable);
 
         return new DataResponse<>(SuccessInfo.MEMBER_LOADED, getMemberDtoList);
     }

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/repository/MemberRepository.java
@@ -5,12 +5,13 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import site.billingwise.api.serverapi.domain.member.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member> {
 
     Optional<Member> findById(Long id);
 

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/repository/MemberSpecification.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/repository/MemberSpecification.java
@@ -1,0 +1,41 @@
+package site.billingwise.api.serverapi.domain.member.repository;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import jakarta.persistence.criteria.Predicate;
+import site.billingwise.api.serverapi.domain.member.Member;
+
+public class MemberSpecification {
+    public static Specification<Member> findMember(
+            String name,
+            String email,
+            String phone,
+            Long clientId) {
+        return ((root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (name != null && !name.isEmpty()) {
+                predicates.add(criteriaBuilder.like(root.get("name"), "%" + name + "%"));
+            }
+
+            if (email != null && !email.isEmpty()) {
+                predicates.add(criteriaBuilder.like(root.get("email"), "%" + email + "%"));
+            }
+
+            if (phone != null && !phone.isEmpty()) {
+                predicates.add(criteriaBuilder.like(root.get("phone"), "%" + phone + "%"));
+            }
+
+            if (clientId != null) {
+                predicates.add(criteriaBuilder.equal(root
+                        .get("client")
+                        .get("id"), clientId));
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        });
+    }
+}

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
@@ -43,31 +43,27 @@ public class MemberService {
     private final Validator validator;
 
     @Transactional
-    public void createMember(CreateMemberDto createMemberDto) {
+    public Long createMember(CreateMemberDto createMemberDto) {
         User user = SecurityUtil.getCurrentUser().orElseThrow(() -> new GlobalException(FailureInfo.NOT_EXIST_USER));
-
-        if (memberRepository.existsByEmail(createMemberDto.getEmail())) {
-            throw new GlobalException(FailureInfo.ALREADY_EXIST_EMAIL);
-        }
 
         Member member = createMemberDto.toEntity(user.getClient());
 
         memberRepository.save(member);
+
+        return member.getId();
     }
 
     @Transactional
-    public void editMember(Long memberId, CreateMemberDto createMemberDto) {
+    public GetMemberDto editMember(Long memberId, CreateMemberDto createMemberDto) {
         User user = SecurityUtil.getCurrentUser().orElseThrow(() -> new GlobalException(FailureInfo.NOT_EXIST_USER));
         Member member = getEntity(user.getClient(), memberId);
-
-        if (memberRepository.existsByEmail(createMemberDto.getEmail())) {
-            throw new GlobalException(FailureInfo.ALREADY_EXIST_EMAIL);
-        }
 
         member.setName(createMemberDto.getName());
         member.setEmail(createMemberDto.getEmail());
         member.setPhone(createMemberDto.getPhone());
         member.setDescription(createMemberDto.getDescription());
+
+        return toGetDtoFromEntity(member);
     }
 
     public void deleteMember(Long memberId) {
@@ -137,7 +133,6 @@ public class MemberService {
     }
 
     private GetMemberDto toGetDtoFromEntity(Member member) {
-        long contractCount = 0L;
         long unPaidCount = 0L;
         long totalInvoiceAmount = 0L;
         long totalUnpaidAmount = 0L;
@@ -153,7 +148,6 @@ public class MemberService {
                 }
             }
 
-            contractCount++;
             if (isUnpaid) {
                 unPaidCount++;
             }
@@ -165,11 +159,11 @@ public class MemberService {
                 .email(member.getEmail())
                 .phone(member.getPhone())
                 .description(member.getDescription())
-                .contractCount(contractCount)
+                .contractCount(member.getContractCount())
                 .unPaidCount(unPaidCount)
                 .totalInvoiceAmount(totalInvoiceAmount)
                 .totalUnpaidAmount(totalUnpaidAmount)
-                .contractCount(contractCount)
+                .contractCount(member.getContractCount())
                 .createdAt(member.getCreatedAt())
                 .updatedAt(member.getUpdatedAt())
                 .build();

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -108,7 +109,6 @@ public class MemberService {
         Client client = user.getClient();
 
         CreateBulkResultDto createBulkResultDto = toCreateBulkResultDto(file);
-
         if (createBulkResultDto.isSuccess()) {
             List<Member> memberList = new ArrayList<>();
             for (CreateMemberDto createMemberDto : createBulkResultDto.getMemberList()) {
@@ -181,7 +181,12 @@ public class MemberService {
 
             Sheet sheet = workbook.getSheetAt(0);
             for (Row row : sheet) {
+                // 첫 행인지 확인
                 if (row.getRowNum() == 0) {
+                    continue;
+                }
+                // 빈 행인지 확인
+                if (!PoiUtil.getNotBlank(row, 4)) {
                     continue;
                 }
 
@@ -199,11 +204,6 @@ public class MemberService {
                     isSuccess = false;
                     bindingResult.getAllErrors()
                             .forEach(error -> errorList.add(row.getRowNum() + "행 : " + error.getDefaultMessage()));
-                }
-
-                if (memberRepository.existsByEmail(createMemberDto.getEmail())) {
-                    isSuccess = false;
-                    errorList.add(row.getRowNum() + "행 : " + "중복된 이메일입니다.");
                 }
 
                 createMemberDtoList.add(createMemberDto);

--- a/src/main/java/site/billingwise/api/serverapi/global/util/PoiUtil.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/util/PoiUtil.java
@@ -2,6 +2,7 @@ package site.billingwise.api.serverapi.global.util;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
 
 import site.billingwise.api.serverapi.global.exception.GlobalException;
 import site.billingwise.api.serverapi.global.response.info.FailureInfo;
@@ -9,7 +10,7 @@ import site.billingwise.api.serverapi.global.response.info.FailureInfo;
 public class PoiUtil {
 
     public static String getCellValue(Cell cell) {
-        if (cell == null) {
+        if (cell == null || cell.getCellType() == CellType.BLANK) {
             return null;
         }
 
@@ -23,7 +24,7 @@ public class PoiUtil {
     }
 
     public static Integer getCellIntValue(Cell cell) {
-        if (cell == null) {
+        if (cell == null || cell.getCellType() == CellType.BLANK) {
             return null;
         }
 
@@ -35,7 +36,7 @@ public class PoiUtil {
     }
 
     public static Long getCellLongValue(Cell cell) {
-        if (cell == null) {
+        if (cell == null || cell.getCellType() == CellType.BLANK) {
             return null;
         }
 
@@ -47,7 +48,7 @@ public class PoiUtil {
     }
 
     public static Boolean getCellBooleanValue(Cell cell) {
-        if (cell == null) {
+        if (cell == null || cell.getCellType() == CellType.BLANK) {
             return null;
         }
 
@@ -56,6 +57,18 @@ public class PoiUtil {
         }
 
         throw new GlobalException(FailureInfo.INVALID_CELL_INPUT);
+    }
+
+    public static Boolean getNotBlank(Row row, int columnCount) {
+
+        for (int i = 0; i < columnCount; i++) {
+            Cell cell = row.getCell(i);
+            if (cell != null && cell.getCellType() != CellType.BLANK) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/src/main/resources/db/migration/V2407241005__delete_constraint.sql
+++ b/src/main/resources/db/migration/V2407241005__delete_constraint.sql
@@ -1,0 +1,9 @@
+alter table member
+    drop foreign key FK41ukictibhnhb6jfpxd1p4h0f;
+
+alter table member
+    drop key UKqjf9724fx8tooue4d7oskpave;
+
+alter table member
+    add constraint member_client_client_id_fk
+        foreign key (client_id) references client (client_id);

--- a/src/test/java/site/billingwise/api/serverapi/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/member/controller/MemberControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -257,7 +258,8 @@ public class MemberControllerTest extends AbstractRestDocsTests {
         List<GetMemberDto> memberList = Arrays.asList(member1, member2);
 
         PageImpl<GetMemberDto> page = new PageImpl<>(memberList, PageRequest.of(0, 20), memberList.size());
-        given(memberService.getMemberList(anyString(), any(Pageable.class))).willReturn(page);
+        given(memberService.getMemberList(nullable(String.class), nullable(String.class),
+                nullable(String.class), any(Pageable.class))).willReturn(page);
 
         // when
         ResultActions result = mockMvc.perform(get(url)
@@ -271,50 +273,84 @@ public class MemberControllerTest extends AbstractRestDocsTests {
                         cookieWithName("access").description("엑세스 토큰")),
                 pathParameters(
                         parameterWithName("name").optional().description("회원명"),
+                        parameterWithName("email").optional().description("이메일"),
+                        parameterWithName("phone").optional().description("전화번호"),
                         parameterWithName("page").optional().description("페이지 번호 (기본값: 0)"),
                         parameterWithName("size").optional().description("페이지 크기 (기본값: 20)")),
                 responseFields(
                         fieldWithPath("code").description("응답 코드").type(JsonFieldType.NUMBER),
-                        fieldWithPath("message").description("응답 메시지").type(JsonFieldType.STRING),
+                        fieldWithPath("message").description("응답 메시지")
+                                .type(JsonFieldType.STRING),
                         fieldWithPath("data").description("응답 데이터").type(JsonFieldType.OBJECT),
-                        fieldWithPath("data.content").description("회원 목록").type(JsonFieldType.ARRAY),
-                        fieldWithPath("data.content[].id").description("회원 ID").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.content[].name").description("회원명").type(JsonFieldType.STRING),
-                        fieldWithPath("data.content[].email").description("회원 이메일").type(JsonFieldType.STRING),
-                        fieldWithPath("data.content[].phone").description("회원 전화번호").type(JsonFieldType.STRING),
-                        fieldWithPath("data.content[].description").description("회원 설명").type(JsonFieldType.STRING),
-                        fieldWithPath("data.content[].contractCount").description("관련 계약수").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.content[].unPaidCount").description("미납된 계약수").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.content[].totalInvoiceAmount").description("총 청구 금액")
+                        fieldWithPath("data.content").description("회원 목록")
+                                .type(JsonFieldType.ARRAY),
+                        fieldWithPath("data.content[].id").description("회원 ID")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.content[].name").description("회원명")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.content[].email").description("회원 이메일")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.content[].phone").description("회원 전화번호")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.content[].description").description("회원 설명")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.content[].contractCount").description("관련 계약수")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.content[].unPaidCount").description("미납된 계약수")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.content[].totalInvoiceAmount")
+                                .description("총 청구 금액")
                                 .type(JsonFieldType.NUMBER),
                         fieldWithPath("data.content[].totalUnpaidAmount").description("총 미납 금액")
                                 .type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.content[].createdAt").description("회원 생성일").type(JsonFieldType.STRING),
-                        fieldWithPath("data.content[].updatedAt").description("회원 정보 수정일").type(JsonFieldType.STRING),
-                        fieldWithPath("data.pageable").description("페이징 정보").type(JsonFieldType.OBJECT),
-                        fieldWithPath("data.pageable.sort").description("정렬 정보").type(JsonFieldType.OBJECT),
+                        fieldWithPath("data.content[].createdAt").description("회원 생성일")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.content[].updatedAt").description("회원 정보 수정일")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("data.pageable").description("페이징 정보")
+                                .type(JsonFieldType.OBJECT),
+                        fieldWithPath("data.pageable.sort").description("정렬 정보")
+                                .type(JsonFieldType.OBJECT),
                         fieldWithPath("data.pageable.sort.empty").description("정렬 정보 비어 있음 여부")
                                 .type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.pageable.sort.sorted").description("정렬 여부").type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.pageable.sort.sorted").description("정렬 여부")
+                                .type(JsonFieldType.BOOLEAN),
                         fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않음 여부")
                                 .type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.pageable.offset").description("페이징 오프셋").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.pageable.pageNumber").description("페이지 번호").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.pageable.pageSize").description("페이지 크기").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.pageable.paged").description("페이징 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.pageable.unpaged").description("페이징되지 않음 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.last").description("마지막 페이지 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.totalPages").description("전체 페이지 수").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.totalElements").description("전체 요소 수").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.size").description("페이지 크기").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.number").description("현재 페이지 번호").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.sort").description("정렬 정보").type(JsonFieldType.OBJECT),
-                        fieldWithPath("data.sort.empty").description("정렬 정보 비어 있음 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.sort.sorted").description("정렬 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.sort.unsorted").description("정렬되지 않음 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.first").description("첫 페이지 여부").type(JsonFieldType.BOOLEAN),
-                        fieldWithPath("data.numberOfElements").description("요소 개수").type(JsonFieldType.NUMBER),
-                        fieldWithPath("data.empty").description("비어 있음 여부").type(JsonFieldType.BOOLEAN))));
+                        fieldWithPath("data.pageable.offset").description("페이징 오프셋")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.pageable.pageNumber").description("페이지 번호")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.pageable.pageSize").description("페이지 크기")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.pageable.paged").description("페이징 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.pageable.unpaged").description("페이징되지 않음 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.last").description("마지막 페이지 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.totalPages").description("전체 페이지 수")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.totalElements").description("전체 요소 수")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.size").description("페이지 크기")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.number").description("현재 페이지 번호")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.sort").description("정렬 정보")
+                                .type(JsonFieldType.OBJECT),
+                        fieldWithPath("data.sort.empty").description("정렬 정보 비어 있음 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.sort.sorted").description("정렬 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.sort.unsorted").description("정렬되지 않음 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.first").description("첫 페이지 여부")
+                                .type(JsonFieldType.BOOLEAN),
+                        fieldWithPath("data.numberOfElements").description("요소 개수")
+                                .type(JsonFieldType.NUMBER),
+                        fieldWithPath("data.empty").description("비어 있음 여부")
+                                .type(JsonFieldType.BOOLEAN))));
     }
 
     @Test
@@ -324,7 +360,8 @@ public class MemberControllerTest extends AbstractRestDocsTests {
         String url = "/api/v1/members/bulk-register";
 
         MockMultipartFile file = new MockMultipartFile("file", "member_test_success.xlsx",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "exel data".getBytes());
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "exel data".getBytes());
 
         CreateMemberDto createMemberDto = CreateMemberDto.builder()
                 .name("kim")

--- a/src/test/java/site/billingwise/api/serverapi/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/member/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Validator;
@@ -187,38 +189,13 @@ public class MemberServiceTest {
 
         Page<Member> memberPage = new PageImpl<>(memberList, PageRequest.of(0, 10), memberList.size());
 
-        when(memberRepository.findByClientId(anyLong(), any(Pageable.class)))
+        when(memberRepository.findAll(any(Specification.class), any(Pageable.class)))
                 .thenReturn(memberPage);
 
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<GetMemberDto> result = memberService.getMemberList(null, pageable);
-
-        // then
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertEquals(10, result.getSize());
-        assertEquals(mockMember.getId(), result.getContent().get(0).getId());
-    }
-
-    @Test
-    public void getetMemberListWithName() {
-        // given
-        when(SecurityUtil.getCurrentUser()).thenReturn(Optional.of(mockUser));
-        List<Member> memberList = new ArrayList<>();
-        memberList.add(mockMember);
-
-        Page<Member> memberPage = new PageImpl<>(memberList, PageRequest.of(0, 10), memberList.size());
-
-        when(memberRepository.findByClientIdAndName(anyLong(), anyString(),
-                any(Pageable.class)))
-                .thenReturn(memberPage);
-
-        Pageable pageable = PageRequest.of(0, 10);
-
-        // when
-        Page<GetMemberDto> result = memberService.getMemberList("Member 1", pageable);
+        Page<GetMemberDto> result = memberService.getMemberList("name", "email@naver.com", "01011111111", pageable);
 
         // then
         assertNotNull(result);

--- a/src/test/java/site/billingwise/api/serverapi/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/member/service/MemberServiceTest.java
@@ -113,16 +113,6 @@ public class MemberServiceTest {
     }
 
     @Test
-    void createMemberEmailExist() {
-        // given
-        when(SecurityUtil.getCurrentUser()).thenReturn(Optional.of(mockUser));
-        when(memberRepository.existsByEmail(createMemberDto.getEmail())).thenReturn(true);
-
-        // when, then
-        assertThrows(GlobalException.class, () -> memberService.createMember(createMemberDto));
-    }
-
-    @Test
     void editMember() {
         // given
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
@@ -137,17 +127,6 @@ public class MemberServiceTest {
         assertEquals(createMemberDto.getEmail(), mockMember.getEmail());
         assertEquals(createMemberDto.getPhone(), mockMember.getPhone());
         assertEquals(createMemberDto.getDescription(), mockMember.getDescription());
-    }
-
-    @Test
-    void editMemberEmailExist() {
-        // given
-        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
-        when(SecurityUtil.getCurrentUser()).thenReturn(Optional.of(mockUser));
-        when(memberRepository.existsByEmail(createMemberDto.getEmail())).thenReturn(true);
-
-        // when, then
-        assertThrows(GlobalException.class, () -> memberService.editMember(1L, createMemberDto));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈

- [K5P-67]

## 구현 기능

- 회원 생서, 수정 API 반환값 추가
- 회원 대량 등록 예외 처리 추가
- 테스트 코드 수정

## 참고 사항

[K5P-67]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ