### PR TITLE
[fix] 동의 관련 API 수정 및 테스트

### DIFF
--- a/src/docs/asciidoc/api/consent.adoc
+++ b/src/docs/asciidoc/api/consent.adoc
@@ -11,7 +11,7 @@
 
 동의정보를 등록합니다. 서명 이미지는 필수입니다.
 
-operation::consent/register[snippets='http-request,request-cookies,request-parts,request-part-data-fields,http-response']
+operation::consent/register[snippets='http-request,request-cookies,request-parts,request-part-data-fields,http-response,response-fields']
 
 === 동의정보 조회
 
@@ -23,13 +23,13 @@ operation::consent/get[snippets='http-request,request-cookies,path-parameters,ht
 
 상품 정보를 수정합니다.
 
-operation::consent/edit[snippets='http-request,request-cookies,path-parameters,request-fields,http-response']
+operation::consent/edit[snippets='http-request,request-cookies,path-parameters,request-fields,http-response,response-fields']
 
 === 동의 서명 이미지 수정
 
 동의 서명 이미지를 수정합니다.
 
-operation::consent/edit-image[snippets='http-request,request-cookies,path-parameters,request-parts,http-response']
+operation::consent/edit-image[snippets='http-request,request-cookies,path-parameters,request-parts,http-response,response-fields']
 
 === 동의정보 삭제
 

--- a/src/main/java/site/billingwise/api/serverapi/domain/consent/controller/ConsentController.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/consent/controller/ConsentController.java
@@ -21,12 +21,14 @@ public class ConsentController {
 
     @PostMapping("/{memberId}")
     @ResponseStatus(HttpStatus.OK)
-    public BaseResponse registerConsent(
+    public DataResponse<GetConsentDto> registerConsent(
             @PathVariable Long memberId,
             @Valid @RequestPart(name = "data") RegisterConsentDto registerConsentDto,
             @RequestPart(name = "signImage") MultipartFile multipartFile) {
-        consentService.registerConsent(memberId, registerConsentDto, multipartFile);
-        return new BaseResponse(SuccessInfo.CONSENT_REGISTERED);
+
+        GetConsentDto getConsentDto = consentService.registerConsent(memberId, registerConsentDto, multipartFile);
+
+        return new DataResponse<>(SuccessInfo.CONSENT_REGISTERED, getConsentDto);
     }
 
     @GetMapping("/{memberId}")
@@ -38,18 +40,21 @@ public class ConsentController {
 
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{memberId}")
-    public BaseResponse editConsent(@PathVariable Long memberId,
-                                    @Valid @RequestBody RegisterConsentDto editConsentDto) {
-        consentService.editConsent(memberId, editConsentDto);
-        return new BaseResponse(SuccessInfo.CONSENT_EDITED);
+    public DataResponse<GetConsentDto> editConsent(@PathVariable Long memberId,
+            @Valid @RequestBody RegisterConsentDto editConsentDto) {
+
+        GetConsentDto getConsentDto = consentService.editConsent(memberId, editConsentDto);
+        return new DataResponse<>(SuccessInfo.CONSENT_EDITED, getConsentDto);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{memberId}/image")
-    public BaseResponse editItemImage(@PathVariable Long memberId,
-                                      @RequestPart(name = "signImage") MultipartFile multipartFile) {
-        consentService.editConsentSignImage(memberId, multipartFile);
-        return new BaseResponse(SuccessInfo.CONSENT_SIGN_IMAGE_EDITED);
+    public DataResponse<GetConsentDto> editItemImage(@PathVariable Long memberId,
+            @RequestPart(name = "signImage") MultipartFile multipartFile) {
+
+        GetConsentDto getConsentDto = consentService.editConsentSignImage(memberId, multipartFile);
+
+        return new DataResponse<>(SuccessInfo.CONSENT_SIGN_IMAGE_EDITED, getConsentDto);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/site/billingwise/api/serverapi/domain/consent/service/EasyConsentService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/consent/service/EasyConsentService.java
@@ -125,11 +125,10 @@ public class EasyConsentService {
         }
 
         List<Contract> contractList = contractRepository
-                .findAllByMemberAndPaymentTypeAndContractStatusAndIsEasyConsent(
+                .findAllByMemberAndPaymentTypeAndContractStatus(
                         contract.getMember(),
                         PaymentType.AUTO_TRANSFER,
-                        ContractStatus.PENDING,
-                        true
+                        ContractStatus.PENDING
                 );
 
         for (Contract c : contractList) {

--- a/src/main/java/site/billingwise/api/serverapi/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/contract/repository/ContractRepository.java
@@ -30,6 +30,10 @@ public interface ContractRepository extends JpaRepository<Contract, Long>, JpaSp
             Member member,
             PaymentType paymentType,
             ContractStatus contractStatus,
-            Boolean isEasyConsent
-    );
+            Boolean isEasyConsent);
+
+    List<Contract> findAllByMemberAndPaymentTypeAndContractStatus(
+            Member member,
+            PaymentType paymentType,
+            ContractStatus contractStatus);
 }

--- a/src/main/java/site/billingwise/api/serverapi/domain/contract/service/ContractService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/contract/service/ContractService.java
@@ -95,11 +95,13 @@ public class ContractService {
         InvoiceType invoiceType = EnumUtil.toEnum(InvoiceType.class, editContractDto.getInvoiceTypeId());
 
         boolean existConsent = consentAccountRepository.existsById(contract.getMember().getId());
-        boolean consentNeeded = !existConsent && editContractDto.getPaymentTypeId() == 2
-                && editContractDto.getIsEasyConsent();
+
+        boolean consentNeeded = !existConsent && editContractDto.getPaymentTypeId() == 2;
         ContractStatus contractStatus = EnumUtil.toEnum(ContractStatus.class, consentNeeded ? 1L : 2L);
 
-        if (consentNeeded) {
+        boolean isEasyConsent = paymentType == PaymentType.PAYER_PAYMENT ? false : editContractDto.getIsEasyConsent();
+
+        if (consentNeeded && isEasyConsent) {
             emailService.createMailConsent(contract.getMember().getEmail(), contract.getId());
         }
 
@@ -107,7 +109,7 @@ public class ContractService {
         contract.setItemAmount(editContractDto.getItemAmount());
         contract.setPaymentType(paymentType);
         contract.setInvoiceType(invoiceType);
-        contract.setIsEasyConsent(editContractDto.getIsEasyConsent());
+        contract.setIsEasyConsent(isEasyConsent);
         contract.setContractCycle(editContractDto.getContractCycle());
         contract.setPaymentDueCycle(editContractDto.getPaymentDueCycle());
         contract.setContractStatus(contractStatus);
@@ -286,8 +288,7 @@ public class ContractService {
         InvoiceType invoiceType = EnumUtil.toEnum(InvoiceType.class, createContractDto.getInvoiceTypeId());
 
         boolean existConsent = consentAccountRepository.existsById(member.getId());
-        boolean consentNeeded = !existConsent && createContractDto.getPaymentTypeId() == 2
-                && createContractDto.getIsEasyConsent();
+        boolean consentNeeded = !existConsent && createContractDto.getPaymentTypeId() == 2;
         ContractStatus contractStatus = EnumUtil.toEnum(ContractStatus.class, consentNeeded ? 1L : 2L);
 
         boolean isEasyConsent = paymentType == PaymentType.PAYER_PAYMENT ? false : createContractDto.getIsEasyConsent();
@@ -306,7 +307,7 @@ public class ContractService {
                 .contractStatus(contractStatus)
                 .build();
 
-        if (consentNeeded) {
+        if (consentNeeded && isEasyConsent) {
             emailArr.add(contract);
         }
 

--- a/src/main/java/site/billingwise/api/serverapi/global/mail/EmailService.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/mail/EmailService.java
@@ -80,6 +80,8 @@ public class EmailService {
     public MimeMessage createMailConsent(String email, Long contractId) {
         MimeMessage message = mailSender.createMimeMessage();
 
+        String url = frontUrl + "m/consent/member/contract-confirmation/" + contractId;
+
         try {
             message.setFrom(fromMail);
             message.setRecipients(MimeMessage.RecipientType.TO, email);
@@ -89,7 +91,7 @@ public class EmailService {
             body += "<h1>" + "빌링와이즈 입니다." + "</h1>";
             body += "<h3>" + "아래 링크를 통해 자동 결제 간편 동의를 완료해주세요" + "</h3><br>";
             body += "<div align='center' style='border:1px solid black; font-family:verdana;'>";
-            body += "<span style='color:blue'>" + frontUrl + "m/consent/member/" + contractId + "</span>";
+            body += "<a href='" + url + "' style='color:blue'>" + "간편 동의 링크" + "</a>";
             body += "</div>";
 
             message.setText(body, "UTF-8", "html");

--- a/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/response/info/FailureInfo.java
@@ -55,7 +55,7 @@ public enum FailureInfo {
 
     // consent
     ALREADY_EXIST_CONSENT(409, "이미 동의서가 존재합니다."),
-    NOT_EXIST_CONSENT(404, "동의서가 존재하지 않습니다."),
+    NOT_EXIST_CONSENT(400, "동의서가 존재하지 않습니다."),
 
     // easy consent
     NOT_CMS(400, "실시간 CMS 계약이 아닙니다."),

--- a/src/test/java/site/billingwise/api/serverapi/domain/consent/service/ConsentServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/consent/service/ConsentServiceTest.java
@@ -13,6 +13,7 @@ import site.billingwise.api.serverapi.domain.consent.ConsentAccount;
 import site.billingwise.api.serverapi.domain.consent.dto.request.RegisterConsentDto;
 import site.billingwise.api.serverapi.domain.consent.dto.response.GetConsentDto;
 import site.billingwise.api.serverapi.domain.consent.repository.ConsentAccountRepository;
+import site.billingwise.api.serverapi.domain.contract.repository.ContractRepository;
 import site.billingwise.api.serverapi.domain.item.Item;
 import site.billingwise.api.serverapi.domain.item.dto.request.CreateItemDto;
 import site.billingwise.api.serverapi.domain.item.service.ItemService;
@@ -29,6 +30,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -38,6 +40,8 @@ public class ConsentServiceTest {
     private ConsentAccountRepository consentAccountRepository;
     @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private ContractRepository contractRepository;
     @Mock
     private S3Service s3Service;
 
@@ -82,7 +86,6 @@ public class ConsentServiceTest {
                 "image/jpeg",
                 "test image content".getBytes());
 
-
         Member member = Member.builder().client(mockClient).build();
 
         ConsentAccount consentAccount = registerConsentDto.toEntity(member, " ");
@@ -90,6 +93,8 @@ public class ConsentServiceTest {
         when(SecurityUtil.getCurrentClient()).thenReturn(mockClient);
 
         when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+
+        when(consentAccountRepository.save(any(ConsentAccount.class))).thenReturn(consentAccount);
 
         when(s3Service.upload(eq(multipartFile), eq(signImageDirectory))).thenReturn("s3://bucket/test.jpg");
 

--- a/src/test/java/site/billingwise/api/serverapi/domain/contract/service/ContractServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/contract/service/ContractServiceTest.java
@@ -172,7 +172,7 @@ public class ContractServiceTest {
                 .itemAmount(2)
                 .invoiceTypeId(1L)
                 .paymentTypeId(1L)
-                .isEasyConsent(true)
+                .isEasyConsent(false)
                 .contractCycle(10)
                 .paymentDueCycle(10)
                 .build();


### PR DESCRIPTION
## 관련 이슈

- [K5P-70]

## 구현 기능

- 간편 동의 및 직접 동의 로직 변경
- 동의 관련 API 반환값 수정
- 테스트 코드 수정

## 참고 사항

[K5P-70]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ