### PR TITLE
[fix] 통계 레스트독스 및 쿼리dsl 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ asciidoctor {
 }
 
 
-def querydslDir = "src/main/generated"
+def querydslDir = "$buildDir/main/generated"
 
 sourceSets {
     main.java.srcDirs += [ querydslDir ]

--- a/src/test/java/site/billingwise/api/serverapi/domain/stats/controller/InvoiceStatsControllerTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/stats/controller/InvoiceStatsControllerTest.java
@@ -68,7 +68,7 @@ public class InvoiceStatsControllerTest extends AbstractRestDocsTests {
 
         // then
         result.andExpect(status().isOk())
-                .andDo(document("stats/get-invoice-stats",
+                .andDo(document("stats/get",
                         requestCookies(
                                 cookieWithName("access").description("엑세스 토큰")),
                         pathParameters(


### PR DESCRIPTION
## 관련 이슈

- [K5P-72] 

## 구현 기능

- 통계API rest docs를 위한 테스트 코드 변경
- 쿼리 dsl 경로 변경

## 참고 사항

[K5P-72]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ