### PR TITLE
 [fix] 문자 메시지 기능 추가, 삭제 api 트랜젝션 처리

### DIFF
--- a/src/main/java/site/billingwise/api/serverapi/domain/invoice/service/InvoiceService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/invoice/service/InvoiceService.java
@@ -35,6 +35,7 @@ import site.billingwise.api.serverapi.domain.user.User;
 import site.billingwise.api.serverapi.global.exception.GlobalException;
 import site.billingwise.api.serverapi.global.mail.EmailService;
 import site.billingwise.api.serverapi.global.response.info.FailureInfo;
+import site.billingwise.api.serverapi.global.sms.SmsService;
 import site.billingwise.api.serverapi.global.util.EnumUtil;
 import site.billingwise.api.serverapi.global.util.SecurityUtil;
 
@@ -44,6 +45,7 @@ public class InvoiceService {
 
     private final ContractService contractService;
     private final EmailService emailService;
+    private final SmsService smsService;
 
     private final InvoiceRepository invoiceRepository;
     private final PaymentRepository paymentRepository;
@@ -66,6 +68,7 @@ public class InvoiceService {
         Member member = invoice.getContract().getMember();
 
         emailService.createMailInvoice(member.getEmail(), invoiceId);
+        smsService.sendConsent(member.getPhone(), invoiceId);
     }
 
     // 청구 생성

--- a/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/item/service/ItemService.java
@@ -81,6 +81,7 @@ public class ItemService {
         return GetItemDto.toDto(item);
     }
 
+    @Transactional
     public void deleteItem(Long itemId) {
         User user = SecurityUtil.getCurrentUser().orElseThrow(
                 () -> new GlobalException(FailureInfo.NOT_EXIST_USER));

--- a/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
+++ b/src/main/java/site/billingwise/api/serverapi/domain/member/service/MemberService.java
@@ -67,6 +67,7 @@ public class MemberService {
         return toGetDtoFromEntity(member);
     }
 
+    @Transactional
     public void deleteMember(Long memberId) {
         User user = SecurityUtil.getCurrentUser().orElseThrow(() -> new GlobalException(FailureInfo.NOT_EXIST_USER));
         Member member = getEntity(user.getClient(), memberId);

--- a/src/main/java/site/billingwise/api/serverapi/global/sms/SmsService.java
+++ b/src/main/java/site/billingwise/api/serverapi/global/sms/SmsService.java
@@ -37,6 +37,9 @@ public class SmsService {
     @Value("${coolsms.api.url}")
     private String url;
 
+    @Value("${front.url}")
+    private String frontUrl;
+
 
     @PostConstruct
     private void init() {
@@ -64,6 +67,32 @@ public class SmsService {
         message.setFrom(sender);
         message.setTo(to);
         message.setText("[빌링와이즈] 아래의 인증번호를 입력해주세요\n" + verificationCode);
+
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        return response;
+    }
+
+    public SingleMessageSentResponse sendConsent(String to, Long contractId) {
+        Message message = new Message();
+
+        String url = frontUrl + "m/consent/member/contract-confirmation/" + contractId;
+
+        message.setFrom(sender);
+        message.setTo(to);
+        message.setText("[빌링와이즈] 아래 링크에 접속하여 간편 동의를 진행해주세요.\n\n" + url);
+
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        return response;
+    }
+
+    public SingleMessageSentResponse sendPayment(String to, Long invoiceId) {
+        Message message = new Message();
+
+        String url = frontUrl + "m/payment/" + invoiceId + "/info";
+
+        message.setFrom(sender);
+        message.setTo(to);
+        message.setText("[빌링와이즈] 아래 링크에 접속하여 결제를 진행해주세요.\n\n" + url);
 
         SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
         return response;

--- a/src/test/java/site/billingwise/api/serverapi/domain/contract/service/ContractServiceTest.java
+++ b/src/test/java/site/billingwise/api/serverapi/domain/contract/service/ContractServiceTest.java
@@ -37,6 +37,7 @@ import site.billingwise.api.serverapi.domain.user.User;
 import site.billingwise.api.serverapi.global.exception.GlobalException;
 import site.billingwise.api.serverapi.global.mail.EmailService;
 import site.billingwise.api.serverapi.global.response.info.FailureInfo;
+import site.billingwise.api.serverapi.global.sms.SmsService;
 import site.billingwise.api.serverapi.global.util.EnumUtil;
 import site.billingwise.api.serverapi.global.util.SecurityUtil;
 
@@ -70,6 +71,9 @@ public class ContractServiceTest {
 
     @Mock
     private EmailService emailService;
+
+    @Mock
+    private SmsService smsService;
 
     @InjectMocks
     private ContractService contractService;
@@ -156,6 +160,7 @@ public class ContractServiceTest {
         when(memberService.getEntity(any(Client.class), anyLong())).thenReturn(mockMember);
         when(consentAccountRepository.existsById(anyLong())).thenReturn(false);
         when(emailService.createMailConsent(anyString(), anyLong())).thenReturn(mockMessage);
+        when(smsService.sendConsent(anyString(), anyLong())).thenReturn(null);
 
         // when
         contractService.createContract(createContractDto);
@@ -181,6 +186,7 @@ public class ContractServiceTest {
         when(contractRepository.findById(anyLong())).thenReturn(Optional.of(mockContract));
         when(consentAccountRepository.existsById(anyLong())).thenReturn(false);
         when(emailService.createMailConsent(anyString(), anyLong())).thenReturn(mockMessage);
+        when(smsService.sendConsent(anyString(), anyLong())).thenReturn(null);
 
         // when
         contractService.editContract(1L, editContractDto);
@@ -330,6 +336,7 @@ public class ContractServiceTest {
 
         doNothing().when(validator).validate(any(), any(BindingResult.class));
         when(emailService.createMailConsent(anyString(), anyLong())).thenReturn(mockMessage);
+        when(smsService.sendConsent(anyString(), anyLong())).thenReturn(null);
 
         InputStream inputStream = getClass().getResourceAsStream("/exel/contract_test_success.xlsx");
         MockMultipartFile file = new MockMultipartFile("file", "contract_test_success.xlsx",


### PR DESCRIPTION
## 관련 이슈

- [K5P-80]

## 구현 기능
- 간편동의, 납부자 결제 문자 메시지 전송
- 삭제 트랜젝션 처리

## 참고 사항

[K5P-80]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ